### PR TITLE
Add `getTimeLeft` method

### DIFF
--- a/src/es6-timed-map.ts
+++ b/src/es6-timed-map.ts
@@ -171,10 +171,10 @@ export default class Es6TimedMap<K, V> {
   }
 
   /**
-   * Gets the remaining time for a key.
+   * Gets the remaining time for an entry given a key.
    * This is just an estimation - the environment ultimately determines when the removal is executed.
    *
-   * @param key the key of a value in the map
+   * @param key the key of an entry in the map
    *
    * @returns The amount of milliseconds left before the entry is ejected, or `undefined` if the key or timer does not exist
    */

--- a/tests/es6-timed-map.spec.ts
+++ b/tests/es6-timed-map.spec.ts
@@ -89,6 +89,37 @@ describe('Es6TimedMap', () => {
     });
     // TODO:
   });
+  describe('getTimeLeft', () => {
+    let nativeDateNow: () => number;
+
+    beforeEach(() => {
+      nativeDateNow = Date.now;
+      Date.now = jest.fn(() => 0);
+    });
+
+    afterEach(() => {
+      Date.now = nativeDateNow;
+    });
+
+    test('returns undefined if timer does not exist', () => {
+      const timeLeft = timedMap.getTimeLeft('fake-key');
+      expect(timeLeft).toBeUndefined();
+    });
+
+    test('returns the correct time left for a valid key', () => {
+      timedMap.set('first-key', 'first-value', 2000);
+
+      Date.now = jest.fn(() => 1000);
+
+      let timeLeft = timedMap.getTimeLeft('first-key');
+      expect(timeLeft).toEqual(1000);
+
+      Date.now = jest.fn(() => 1500);
+
+      timeLeft = timedMap.getTimeLeft('first-key');
+      expect(timeLeft).toEqual(500);
+    });
+  });
   describe('has', () => {
     test.todo('exists');
     test.todo('returns true');


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**
Add `getTimeLeft` method to return the amount of time before an entry is ejected.

**Which issue (if any) does this pull request address?**
Resolves https://github.com/bradtaniguchi/es6-timed-map/issues/32.

**Is there anything you'd like reviewers to focus on?**
Note that the time left is just an estimation since the environment ultimately determines when the `setTimeout`'s callback is executed : https://stackoverflow.com/questions/21097421/what-is-the-reason-javascript-settimeout-is-so-inaccurate

Open to discuss any other ideas / approaches!